### PR TITLE
Refactor performance enhancement mode for L3 and L7 settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -590,10 +590,9 @@ resource "volterra_aws_vpc_site" "this" {
       #-----------------------------------------------------
 
       performance_enhancement_mode {
-        perf_mode_l7_enhanced {
-          jumbo_disabled = (null == var.jumbo || false == var.jumbo) ? true : null
-          jumbo_enabled  = (true == var.jumbo) ? true : null
-
+        perf_mode_l3_enhanced {
+          no_jumbo = (null == var.jumbo || false == var.jumbo) ? true : null
+          jumbo    = (true == var.jumbo) ? true : null
         }
       }
     }


### PR DESCRIPTION
This pull request updates the configuration for performance enhancement mode in the `volterra_aws_vpc_site` resource. The main change is switching from Layer 7 (L7) to Layer 3 (L3) enhanced performance mode and updating the related jumbo frame options.

Performance mode configuration update:

* Changed the `performance_enhancement_mode` block to use `perf_mode_l3_enhanced` instead of `perf_mode_l7_enhanced`, and updated the jumbo frame attribute names from `jumbo_disabled`/`jumbo_enabled` to `no_jumbo`/`jumbo`. This aligns the configuration with Layer 3 enhanced mode requirements.